### PR TITLE
stringify nested obj in track.properties

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -92,5 +92,24 @@ Woopra.prototype.identify = function(identify) {
  */
 
 Woopra.prototype.track = function(track) {
-  window.woopra.track(track.event(), track.properties());
+  window.woopra.track(track.event(), stringifyNested(track.properties()));
 };
+
+/**
+ * Stringify nested objects.
+ *
+ * Undocumented aspect of Woopra's API, but apparently required. Breaks
+ * on `Completed Order` `properties.products`.
+ *
+ * @param {Object} obj
+ * @return {Object}
+ * @api private
+ */
+
+function stringifyNested(obj){
+  return Object.keys(obj).reduce(function(ret, key){
+    if (Array.isArray(obj[key])) ret[key] = JSON.stringify(obj[key]);
+    else ret[key] = obj[key];
+    return ret;
+  }, {});
+}

--- a/test/index.test.js
+++ b/test/index.test.js
@@ -221,6 +221,23 @@ describe('Woopra', function() {
         analytics.track('event', { property: 'Property' });
         analytics.called(window.woopra.track, 'event', { property: 'Property' });
       });
+
+      it('should stringify nested objects', function(){
+        analytics.track('event', {
+          products: [
+              {
+                sku: '45790-32',
+                name: 'Monopoly: 3rd Edition'
+              },
+              {
+                sku: '46493-32',
+                name: 'Uno Card Game'
+              }
+            ],
+          orderId: 1
+        });
+        analytics.called(window.woopra.track, 'event', { products: '[{"sku":"45790-32","name":"Monopoly: 3rd Edition"},{"sku":"46493-32","name":"Uno Card Game"}]', orderId: 1 });
+      });
     });
   });
 });


### PR DESCRIPTION
@f2prateek 

ZD ticket ref: https://segment.zendesk.com/agent/tickets/34176

We stringify nested objects like `properties.product` for `.track()` events like `Completed Order` since this is an undocumented spec requirement of Woopra.

Confirmed with their rep that this should be the same case for our client side integration so I've just copied the implementation from our server side integration. 

https://github.com/segmentio/integration-woopra/blob/master/lib/mapper.js#L132-L138
